### PR TITLE
Switch version 3.4.11 to 3.4.12

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 DISTRIBUTION = $(shell lsb_release -sc)
-VERSION = 3.4.11
+VERSION = 3.4.12
 PACKAGEVERSION = $(VERSION)-0~$(DISTRIBUTION)1
 TARBALL = zookeeper-$(VERSION).tar.gz
 URL = https://apache.org/dist/zookeeper/zookeeper-$(VERSION)/$(TARBALL)


### PR DESCRIPTION
Tried to build package and end up with:
```
[bionic] --2018-05-24 09:43:59--  https://apache.org/dist/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz
[bionic] Resolving apache.org (apache.org)... 40.79.78.1, 195.154.151.36
[bionic] Connecting to apache.org (apache.org)|40.79.78.1|:443... connected.
[bionic] HTTP request sent, awaiting response... 404 Not Found
[bionic] 2018-05-24 09:44:00 ERROR 404: Not Found.
```