### PR TITLE
new zk package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 DISTRIBUTION = $(shell lsb_release -sc)
-VERSION = 3.4.13
+VERSION = 3.5.5
 PACKAGEVERSION = $(VERSION)-0~$(DISTRIBUTION)1
 TARBALL = zookeeper-$(VERSION).tar.gz
 URL = https://apache.org/dist/zookeeper/zookeeper-$(VERSION)/$(TARBALL)


### PR DESCRIPTION
From https://zookeeper.apache.org/releases.html

20 May, 2019: release 3.5.5 available
First stable version of 3.5 branch. This release is considered to be the successor of 3.4 stable branch and recommended for production use.
It contains 950 commits, resolves 744 issues, fixes 470 bugs and includes the following new features:

Dynamic reconfiguration
Local sessions
New node types: Container, TTL
SSL support for Atomic Broadcast Protocol
Ability to remove watchers
Multi-threaded commit processor
Upgraded to Netty 4.1
Maven build
Various performance and stability improvements.

Please also note:

Minimum recommended JDK version is now 1.8
Release artifacts have been changed considerably:
apache-zookeeper-X.Y.Z.tar.gz is standard source-only release,
apache-zookeeper-X.Y.Z-bin.tar.gz is the convenience tarball which contains the binaries
Thanks to the contributors for their tremendous efforts to make this release happen.